### PR TITLE
NOISSUE - Add domainId to SendMessages Function

### DIFF
--- a/.changeset/empty-years-yell.md
+++ b/.changeset/empty-years-yell.md
@@ -1,0 +1,5 @@
+---
+"@absmach/magistrala-sdk": patch
+---
+
+Add domainId to Send Messages

--- a/examples/messages.ts
+++ b/examples/messages.ts
@@ -14,7 +14,7 @@ const token = "<token>";
 const domainId = "<domainId>";
 
 mySdk.messages
-  .Send(domainId, "<channelId>", "<message>", "<clientKey>")
+  .Send(domainId, "<topic>", "<secret>", "<message>")
   .then((response: any) => {
     console.log("response: ", response);
   })

--- a/examples/messages.ts
+++ b/examples/messages.ts
@@ -13,7 +13,7 @@ const mySdk = new SDK({
 const token = "<token>";
 
 mySdk.messages
-  .Send("<channelId>", "<message>", "<clientKey>")
+  .Send("<channelId>", "<message>", "<clientKey>", "domainid")
   .then((response: any) => {
     console.log("response: ", response);
   })

--- a/examples/messages.ts
+++ b/examples/messages.ts
@@ -23,7 +23,7 @@ mySdk.messages
   });
 
 mySdk.messages
-  .Read({ offset: 0, limit: 10 }, "<channelId>", token, "<domainId>")
+  .Read({ offset: 0, limit: 10 }, "<channelId>", token, domainId)
   .then((response: any) => {
     console.log("response: ", response);
   })

--- a/examples/messages.ts
+++ b/examples/messages.ts
@@ -11,9 +11,10 @@ const mySdk = new SDK({
 });
 
 const token = "<token>";
+const domainId = "<domainId>";
 
 mySdk.messages
-  .Send("<channelId>", "<message>", "<clientKey>", "domainid")
+  .Send(domainId, "<channelId>", "<message>", "<clientKey>")
   .then((response: any) => {
     console.log("response: ", response);
   })

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -45,13 +45,15 @@ export default class Messages {
    *       bytes format for example:
    *       [{"bn":"demo", "bu":"V", "n":"voltage", "u":"V", "v":5}]
    * @param {string} clientKey - The secret of the client sending the message.
+   * @param {string} domainId - The unique ID of the domain of the channel and the client.
    * @returns {Promise<Response>} response - A promise that resolves when the message is sent.
    * @throws {Error} - If the message cannot be sent.
    */
   public async Send(
     channelId: string,
     msg: string,
-    clientKey: string
+    clientKey: string,
+    domainId: string,
   ): Promise<Response> {
     const chanNameParts = channelId.split(".");
     const chanId = chanNameParts.shift()!;
@@ -67,7 +69,7 @@ export default class Messages {
     };
     try {
       const response = await fetch(
-        new URL(`c/${chanId}/m/${subtopic}`, this.httpAdapterUrl).toString(),
+        new URL(`m/${domainId}/c/${chanId}/${subtopic}`, this.httpAdapterUrl).toString(),
         options
       );
       if (!response.ok) {

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -41,29 +41,29 @@ export default class Messages {
   /**
    * @method Send- Sends message to a given Channel via HTTP adapter. The client and Channel must exist and the client connected to the Channel.
    * @param {string} domainId - The unique ID of the domain of the channel and the client.
-   * @param {string} channelId - The ID of the Channel to send the message to.
+   * @param {string} topic - The topic to send the message to.
    * @param {string} msg - Message to send to the Channel that should be in encoded into
    *       bytes format for example:
    *       [{"bn":"demo", "bu":"V", "n":"voltage", "u":"V", "v":5}]
-   * @param {string} clientKey - The secret of the client sending the message.
+   * @param {string} secret - The secret of the client sending the message.
    * @returns {Promise<Response>} response - A promise that resolves when the message is sent.
    * @throws {Error} - If the message cannot be sent.
    */
   public async Send(
     domainId: string,
-    channelId: string,
-    msg: string,
-    clientKey: string,
+    topic: string,
+    secret: string,
+    msg: string
   ): Promise<Response> {
-    const chanNameParts = channelId.split(".");
-    const chanId = chanNameParts.shift()!;
-    const subtopic = chanNameParts.join("/");
+    const topicParts = topic.split(".");
+    const chanId = topicParts.shift()!;
+    const subtopic = topicParts.join("/");
 
     const options: RequestInit = {
       method: "POST",
       headers: {
         "Content-Type": this.contentType,
-        Authorization: `Client ${clientKey}`,
+        Authorization: `Client ${secret}`,
       },
       body: msg,
     };

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -40,20 +40,20 @@ export default class Messages {
 
   /**
    * @method Send- Sends message to a given Channel via HTTP adapter. The client and Channel must exist and the client connected to the Channel.
+   * @param {string} domainId - The unique ID of the domain of the channel and the client.
    * @param {string} channelId - The ID of the Channel to send the message to.
    * @param {string} msg - Message to send to the Channel that should be in encoded into
    *       bytes format for example:
    *       [{"bn":"demo", "bu":"V", "n":"voltage", "u":"V", "v":5}]
    * @param {string} clientKey - The secret of the client sending the message.
-   * @param {string} domainId - The unique ID of the domain of the channel and the client.
    * @returns {Promise<Response>} response - A promise that resolves when the message is sent.
    * @throws {Error} - If the message cannot be sent.
    */
   public async Send(
+    domainId: string,
     channelId: string,
     msg: string,
     clientKey: string,
-    domainId: string,
   ): Promise<Response> {
     const chanNameParts = channelId.split(".");
     const chanId = chanNameParts.shift()!;

--- a/tests/messages.test.ts
+++ b/tests/messages.test.ts
@@ -48,7 +48,7 @@ describe("Messages", () => {
       JSON.stringify({ status: 200, message: "Message sent successfully" }),
     );
 
-    const response = await sdk.messages.Send(channelId, msg, clientKey);
+    const response = await sdk.messages.Send(channelId, msg, clientKey, domainId);
     expect(response).toEqual({
       status: 200,
       message: "Message sent successfully",

--- a/tests/messages.test.ts
+++ b/tests/messages.test.ts
@@ -48,7 +48,7 @@ describe("Messages", () => {
       JSON.stringify({ status: 200, message: "Message sent successfully" }),
     );
 
-    const response = await sdk.messages.Send(channelId, msg, clientKey, domainId);
+    const response = await sdk.messages.Send(domainId, channelId, msg, clientKey);
     expect(response).toEqual({
       status: 200,
       message: "Message sent successfully",

--- a/tests/messages.test.ts
+++ b/tests/messages.test.ts
@@ -14,6 +14,7 @@ const sdk = new SDK({ readersUrl, httpAdapterUrl });
 
 describe("Messages", () => {
   const channelId = "bb7edb32-2eac-4aad-aebe-ed96fe073879";
+  const topic = "bb7edb32-2eac-4aad-aebe-ed96fe073879";
   const message: SenMLMessage = {
     channel: "aecf0902-816d-4e38-a5b3-a1ad9a7cf9e8",
     publisher: "2766ae94-9a08-4418-82ce-3b91cf2ccd3e",
@@ -24,7 +25,7 @@ describe("Messages", () => {
     value: 120.1,
   };
   const msg = '[{"n": "temp","bu": "C","u": "C","v": 23000}]';
-  const clientKey = "bb7edb32-2eac-4aad-aebe-ed96fe073879";
+  const secret = "bb7edb32-2eac-4aad-aebe-ed96fe073879";
   const token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJiYjdlZGIzM";
   const domainId = "bb7edb32-2eac-4aad-aebe-ed96fe073879";
   const queryParams = {
@@ -48,7 +49,7 @@ describe("Messages", () => {
       JSON.stringify({ status: 200, message: "Message sent successfully" }),
     );
 
-    const response = await sdk.messages.Send(domainId, channelId, msg, clientKey);
+    const response = await sdk.messages.Send(domainId, topic, secret, msg);
     expect(response).toEqual({
       status: 200,
       message: "Message sent successfully",


### PR DESCRIPTION
<!-- Copyright (c) Abstract Machines
SPDX-License-Identifier: Apache-2.0 -->

<!-- Pull request title should be `TSSDK-XXX - description` or `NOISSUE - description` where XXX is ID of issue that this PR relate to.
Please review the [CONTRIBUTING.md](./CONTRIBUTING.md) file for detailed contributing guidelines. -->

### What does this do?
This updates the sendMessages function to match the backend by fixing the url to 
```
const response = await fetch(
        new URL(`m/${domainId}/c/${chanId}/${subtopic}`, this.httpAdapterUrl).toString(),
        options
      );
```
### Which issue(s) does this PR fix/relate to?

<!-- Put here `Resolves #XXX` to auto-close the issue that your PR fixes (if such) -->
NONE
### List any changes that modify/break current functionality

### Have you included tests for your changes?
YES
### Did you document any new/modified functionality?
YES
### Notes
